### PR TITLE
Improve agent registration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,53 @@ This will start Keycloak, Redis, the delegation broker and a placeholder agent r
 The broker listens on `http://localhost:8081`.
 
 ### Register an Agent
-`POST /register-agent` with a Bearer token obtained from Keycloak and JSON body:
-```json
-{
-  "role": "data-fetcher",
-  "token_ttl": 3600
-}
-```
-On success the broker returns the generated DID and a signed delegation credential.
+
+1. **Authenticate to Keycloak** to obtain an access token. The default realm
+   contains a public client `agent-identity-cli` and two demo users. Retrieve a
+   token using the password grant:
+
+   ```bash
+   curl -X POST \
+     -d 'client_id=agent-identity-cli' \
+     -d 'grant_type=password' \
+     -d 'username=alice' \
+     -d 'password=password' \
+     http://localhost:8080/realms/agent-identity-poc/protocol/openid-connect/token
+   ```
+
+   The JSON response contains an `access_token` field.
+
+2. **Call the broker** with the obtained token:
+
+   ```bash
+   curl -X POST http://localhost:8081/register-agent \
+     -H "Authorization: Bearer <access_token>" \
+     -H "Content-Type: application/json" \
+     -d '{"role":"data-fetcher","token_ttl":3600}'
+   ```
+
+   On success the broker returns the generated DID and a signed delegation
+   credential. An example response is shown below:
+
+   ```json
+   {
+     "did": "did:example:123",
+     "credential": {
+       "@context": "https://www.w3.org/2018/credentials/v1",
+       "type": [
+         "VerifiableCredential",
+         "AgentDelegation"
+       ],
+       "issuer": "http://localhost:8081",
+       "issuanceDate": "2025-07-24T13:52:35Z",
+       "credentialSubject": {
+         "id": "did:example:123",
+         "metadata": {
+           "role": "data-fetcher",
+           "token_ttl": 3600
+         }
+       },
+       "proof": "/rL2t/Ch9aklOZaV5fuamV/RwEfiuO/EfW5rBlNiL6k="
+     }
+   }
+   ```


### PR DESCRIPTION
## Summary
- document how to request an auth token from Keycloak
- show the full `register-agent` request including the token header
- add an example response from the broker

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68823a0496d0832c9bed3956812c7eb9