### PR TITLE
Add Keycloak direct access and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,33 @@ The broker listens on `http://localhost:8081`.
      }
    }
    ```
+
+## Keycloak Configuration
+
+Import the provided realm export at `keycloak/agent-realm-export.json` when starting Keycloak.
+You can either copy it into the container and pass `--import-realm` on startup,
+or use the admin console to select **Add realm -> Import** and upload the file.
+
+After the realm is loaded, the client `agent-identity-cli` has *Direct Access Grants Enabled*.
+You can verify this by requesting a token using the password grant:
+
+```bash
+curl -X POST \
+  -d 'client_id=agent-identity-cli' \
+  -d 'grant_type=password' \
+  -d 'username=alice' \
+  -d 'password=password' \
+  http://localhost:8080/realms/agent-identity-poc/protocol/openid-connect/token
+```
+
+Decoding the `access_token` should show the audience claim injected by the protocol mapper:
+
+```json
+{
+  "preferred_username": "alice",
+  "aud": "agent-identity-cli"
+}
+```
+
+This configuration is required so the broker and runner components can validate tokens issued to the CLI.
+

--- a/keycloak/agent-realm-export.json
+++ b/keycloak/agent-realm-export.json
@@ -1,0 +1,74 @@
+{
+  "realm": "agent-identity-poc",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "agent-identity-cli",
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "redirectUris": ["*"],
+      "directAccessGrantsEnabled": true,
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "claim.name": "aud",
+            "jsonType.label": "String",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "agent_creator",
+        "description": "Can register and delegate to agents"
+      },
+      {
+        "name": "agent_executor",
+        "description": "Can act on behalf of delegated tasks"
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "alice",
+      "enabled": true,
+      "firstName": "Alice",
+      "lastName": "Agent",
+      "email": "alice@example.com",
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["agent_creator"]
+    },
+    {
+      "username": "bob",
+      "enabled": true,
+      "firstName": "Bob",
+      "lastName": "Builder",
+      "email": "bob@example.com",
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["agent_executor"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add new Keycloak realm export with direct access grants and audience mapper
- document how to import the realm and validate access tokens

## Testing
- `go test ./... -v`

------
https://chatgpt.com/codex/tasks/task_e_6882de83daf0832c96708c7a129ea00e