### PR TITLE
Add execute endpoint with credential verification

### DIFF
--- a/broker/handlers/execute.go
+++ b/broker/handlers/execute.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/bradtumy/agent-identity-poc/internal/audit"
+	"github.com/bradtumy/agent-identity-poc/internal/vc"
+)
+
+// ExecuteRequest payload for POST /execute
+type ExecuteRequest struct {
+	Credential string      `json:"credential"`
+	Task       TaskRequest `json:"task"`
+}
+
+// TaskRequest describes an agent action
+type TaskRequest struct {
+	Action string                 `json:"action"`
+	Params map[string]interface{} `json:"params"`
+}
+
+// ExecuteHandler handles POST /execute requests
+func ExecuteHandler(signingSecret []byte) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req ExecuteRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+
+		var cred vc.Credential
+		if err := json.Unmarshal([]byte(req.Credential), &cred); err != nil {
+			http.Error(w, "invalid credential", http.StatusBadRequest)
+			return
+		}
+
+		if err := vc.Verify(&cred, signingSecret); err != nil {
+			audit.LogAction("execute", cred.CredentialSubject["id"].(string), false)
+			http.Error(w, "invalid credential", http.StatusForbidden)
+			return
+		}
+
+		meta, ok := cred.CredentialSubject["metadata"].(map[string]interface{})
+		if !ok {
+			http.Error(w, "invalid credential metadata", http.StatusForbidden)
+			return
+		}
+		role, _ := meta["role"].(string)
+		ttl, _ := meta["token_ttl"].(float64)
+		issued, err := time.Parse(time.RFC3339, cred.IssuanceDate)
+		if err != nil {
+			http.Error(w, "invalid issuance date", http.StatusForbidden)
+			return
+		}
+		if time.Now().After(issued.Add(time.Duration(ttl) * time.Second)) {
+			audit.LogAction("execute", cred.CredentialSubject["id"].(string), false)
+			http.Error(w, "credential expired", http.StatusForbidden)
+			return
+		}
+		if role != "data-fetcher" {
+			audit.LogAction("execute", cred.CredentialSubject["id"].(string), false)
+			http.Error(w, "unauthorized role", http.StatusForbidden)
+			return
+		}
+
+		// Log success
+		audit.LogAction("execute", cred.CredentialSubject["id"].(string), true)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"result": "ok"})
+	}
+}

--- a/broker/main.go
+++ b/broker/main.go
@@ -51,16 +51,15 @@ func main() {
 	}
 
 	r := mux.NewRouter()
-  
+
 	r.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	})
 
 	r.Handle("/register-agent", auth.Middleware(handlers.RegisterAgentHandler(store, issuer, signingSecret))).Methods(http.MethodPost)
 	r.Handle("/delegate", auth.Middleware(handlers.DelegateHandler(issuer, privKey))).Methods(http.MethodPost)
+	r.Handle("/execute", handlers.ExecuteHandler(signingSecret)).Methods(http.MethodPost)
 
-	port := getenv("BROKER_PORT", "8081")
-  
 	log.Printf("Delegation Broker running on port %s...\n", port)
 	if err := http.ListenAndServe(":"+port, r); err != nil {
 		log.Fatalf("Server failed: %v", err)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,0 +1,8 @@
+package audit
+
+import "log"
+
+// LogAction logs an action for auditing purposes.
+func LogAction(action string, subject string, success bool) {
+	log.Printf("AUDIT action=%s subject=%s success=%t", action, subject, success)
+}


### PR DESCRIPTION
## Summary
- implement `/execute` POST handler with TTL and role checks
- add audit logging package
- add credential verification helper
- register new route in broker

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68838f51b198832cb2884e1f3aff3a41