### PR TITLE
Fix execute handler syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,7 @@ client will work.
 }
 ```
 
-Use the credential returned by `/register-agent` directly in the request body.
-=======
-Use the credential returned by `/register-agent`. Postman may require escaping
-quotes or using environment variables to include the full JSON string.
+Use the credential returned by `/register-agent`. Postman may require escaping quotes or using environment variables to include the full JSON string.
 
 Sending the request will return a stubbed result when the credential is valid:
 


### PR DESCRIPTION
## Summary
- repair broker execute handler braces
- clean README docs for execute endpoint

## Testing
- `go test ./... -v`

------
https://chatgpt.com/codex/tasks/task_e_688399082310832cb21dea475b69332d